### PR TITLE
feat: Create website for Cheersware License

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,25 @@
-# Cheersware License
+# Cheersware License Website
 
-In a world where software powers nearly every aspect of our lives, the licenses
-governing its use have become increasingly complex, legalistic, and at times,
-intimidating. While it's important to protect intellectual property and ensure
-clarity around usage rights, many developers—especially those building for the
-open-source community—are less interested in enforcing control and more
-interested in spreading utility, creativity, and collaboration.
+This repository hosts the source code for the official website of the **🍻 Cheersware License**.
 
-The Cheersware License was born out of this spirit: a desire to make software
-licensing simple, human, and free of legal entanglements—while still providing a
-nod to the value that open work brings to others.
+The website aims to:
+- Clearly present the Cheersware License text.
+- Explain the motivation and philosophy behind it.
+- Make it easy for anyone to adopt the license for their own projects.
 
-At its core, Cheersware is a celebration of human connection. It assumes good
-faith. It encourages kindness. And it replaces restrictive clauses and
-intimidating legalese with something more familiar: a friendly invitation to
-share a drink—be it a coffee, tea, beer, or anything that brings people
-together. It says: “Use this freely. And if it helps you, raise a glass next
-time we meet.”
+## About the Cheersware License
 
-## Why Cheersware?
+The Cheersware License is a simple, human-readable license that encourages sharing and gratitude. Instead of complex legal jargon, it suggests a simple "cheers" – a coffee, tea, or beer – if you find the licensed software useful and happen to meet the author.
 
-* Simple to understand: No jargon, no subclauses, no "Section 9.4(a)(iii)"
-  confusion. Just a clear, readable license you can grasp in a single breath.
-* No legal BS: We’ve stripped away the intimidating parts. This license isn't
-  here to trap you—it's here to empower you.
-* Encourages freedom: You can use the code, modify it, redistribute it,
-  commercialize it—anything. No strings attached.
-* Celebrates gratitude: The only “condition” is not legal—it's social. If this
-  code makes your day easier, you're invited to say thanks, perhaps over a
-  drink, if life brings us together.
+## How to Use the Cheersware License in Your Project
 
-## Who Is It For?
+1.  **Copy the license text:** Go to the [Cheersware License Website](https://your-github-username.github.io/your-repo-name/) (replace with the actual GitHub Pages URL once deployed) or grab the text from the `LICENSE` file in this repository.
+2.  **Create a `LICENSE` file:** In the root of your project, create a file named `LICENSE` or `LICENSE.md`.
+3.  **Paste the text:** Paste the full Cheersware License text into this file.
+4.  **Update the copyright:** Change `[year]` and `[author]` in the license text to your project's year and your name/organization.
 
-Cheersware is for developers, artists, makers, and tinkerers who want to:
+That's it! You're ready to share your project with the Cheersware License.
 
-* Share their work without overthinking legal implications.
-* Foster a culture of openness and gratitude.
-* Avoid license fatigue from choosing between dozens of licenses that all say
-  more or less the same thing.
-* Contribute to a friendlier open-source ecosystem.
+---
 
-This license isn’t about control—it's about trust and community. You don’t need
-a lawyer to understand it. You just need to believe that sharing knowledge
-should be as effortless as clinking glasses.
-
-So go ahead—fork it, build on it, remix it, sell it, teach with it. And if you
-feel like it helped you, maybe say “cheers” someday.
-
-That’s it.
+This website is designed to be hosted on GitHub Pages.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cheersware License</title>
+    <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>🍻 Cheersware License</h1>
+    </header>
+
+    <main>
+        <section id="license-text">
+            <h2>📜 License Text</h2>
+            <pre>
+Copyright © [year] [author]
+
+As long as you retain this notice, you can do whatever you want with this
+software. If we meet someday and you feel like this project helped you, you can
+say “cheers” with a coffee, tea, beer, or any drink of your choice.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OF OTHER DEALINGS IN THE SOFTWARE.
+            </pre>
+        </section>
+
+        <section id="motivation">
+            <h2>📖 Motivation Behind the Cheersware License</h2>
+            <p>In a world where software powers nearly every aspect of our lives, the licenses
+governing its use has become increasingly complex, legalistic, and at times,
+intimidating. While it's important to protect intellectual property and ensure
+Clarity around usage rights, many developers, especially those building for the
+open-source community is less interested in enforcing control and more
+interested in spreading utility, creativity, and collaboration.</p>
+            <p>The <strong>Cheersware License</strong> was born out of this spirit: a desire to make
+software licensing <strong>simple</strong>, <strong>human</strong>, and <strong>free of legal entanglements</strong>
+while still providing a nod to the value that open work brings to others.</p>
+            <p>At its core, Cheersware is a celebration of human connection. It assumes good
+faith. It encourages kindness. And it replaces restrictive clauses and
+intimidating legalese with something more familiar:
+<strong>a friendly invitation to share a drink </strong>- be it a coffee, tea, beer, or
+anything that brings people together. It says: <em>“Use this freely. And if it
+helps you, raise a glass next time we meet.”</em></p>
+        </section>
+
+        <section id="why-cheersware">
+            <h2>💡 Why Cheersware?</h2>
+            <ul>
+                <li><strong>Simple to understand</strong>: No jargon, no subclauses, no "Section 9.4(a)(iii)"
+                  confusion. Just a clear, readable license you can grasp in a single breath.</li>
+                <li><strong>No legal BS</strong>: We’ve stripped away the intimidating parts. This license
+                  isn't here to trap you—it's here to empower you.</li>
+                <li><strong>Encourages freedom</strong>: You can use the code, modify it, redistribute it,
+                  commercialise it—anything. No strings attached.</li>
+                <li><strong>Celebrates gratitude</strong>: The only “condition” is not legal—it's social.
+                  If this code makes your day easier, you're invited to say thanks, perhaps over
+                  a drink, if life brings us together.</li>
+            </ul>
+        </section>
+
+        <section id="who-is-it-for">
+            <h2>🧑‍💻 Who Is It For?</h2>
+            <p>Cheersware is for developers, artists, makers, and tinkerers who want to:</p>
+            <ul>
+                <li>Share their work without overthinking legal implications.</li>
+                <li>Foster a culture of openness and gratitude.</li>
+                <li>Avoid license fatigue from choosing between dozens of licenses that all say
+                  more or less the same thing.</li>
+                <li>Contribute to a friendlier open-source ecosystem.</li>
+            </ul>
+            <p>This license isn’t about control—it's about <strong>trust</strong> and <strong>community</strong>. You
+don’t need a lawyer to understand it. You just need to believe that sharing
+knowledge should be as effortless as clinking glasses.</p>
+            <p>So go ahead—fork it, build on it, remix it, sell it, teach with it. And if you
+feel like it helped you, maybe say “cheers” someday.</p>
+            <p>That’s it.</p>
+        </section>
+
+        <section id="how-to-use">
+            <h2>🚀 How to Use</h2>
+            <p>To use the Cheersware License in your project, simply copy the full license text below and paste it into a file named <code>LICENSE</code> or <code>LICENSE.md</code> in the root of your repository.</p>
+            <h3>Copy License Text:</h3>
+            <pre>
+# 🍻 Cheersware License (v1.0)
+
+Copyright © [year] [author]
+
+As long as you retain this notice, you can do whatever you want with this
+software. If we meet someday and you feel like this project helped you, you can
+say “cheers” with a coffee, tea, beer, or any drink of your choice.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OF OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+## 🍵 Motivation Behind the Cheersware License
+
+In a world where software powers nearly every aspect of our lives, the licenses
+governing its use has become increasingly complex, legalistic, and at times,
+intimidating. While it's important to protect intellectual property and ensure
+Clarity around usage rights, many developers, especially those building for the
+open-source community is less interested in enforcing control and more
+interested in spreading utility, creativity, and collaboration.
+
+The **Cheersware License** was born out of this spirit: a desire to make
+software licensing **simple**, **human**, and **free of legal entanglements**
+while still providing a nod to the value that open work brings to others.
+
+At its core, Cheersware is a celebration of human connection. It assumes good
+faith. It encourages kindness. And it replaces restrictive clauses and
+intimidating legalese with something more familiar:
+**a friendly invitation to share a drink **- be it a coffee, tea, beer, or
+anything that brings people together. It says: _“Use this freely. And if it
+helps you, raise a glass next time we meet.”_
+
+### Why Cheersware?
+
+- **Simple to understand**: No jargon, no subclauses, no "Section 9.4(a)(iii)"
+  confusion. Just a clear, readable license you can grasp in a single breath.
+- **No legal BS**: We’ve stripped away the intimidating parts. This license
+  isn't here to trap you—it's here to empower you.
+- **Encourages freedom**: You can use the code, modify it, redistribute it,
+  commercialise it—anything. No strings attached.
+- **Celebrates gratitude**: The only “condition” is not legal—it's social.
+  If this code makes your day easier, you're invited to say thanks, perhaps over
+  a drink, if life brings us together.
+
+### Who Is It For?
+
+Cheersware is for developers, artists, makers, and tinkerers who want to:
+
+- Share their work without overthinking legal implications.
+- Foster a culture of openness and gratitude.
+- Avoid license fatigue from choosing between dozens of licenses that all say
+  more or less the same thing.
+- Contribute to a friendlier open-source ecosystem.
+
+This license isn’t about control—it's about **trust** and **community**. You
+don’t need a lawyer to understand it. You just need to believe that sharing
+knowledge should be as effortless as clinking glasses.
+
+So go ahead—fork it, build on it, remix it, sell it, teach with it. And if you
+feel like it helped you, maybe say “cheers” someday.
+
+That’s it.
+            </pre>
+        </section>
+    </main>
+
+    <footer>
+        <p>Created with ❤️ for the open-source community.</p>
+    </footer>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,136 @@
+/* Existing styles from index.html - will be modified */
+body {
+    font-family: sans-serif; /* Will be updated */
+    margin: 0; /* Updated from 40px to 0, padding will be added */
+    padding: 20px; /* Added padding */
+    background-color: #FFFDD0; /* Light, warm background - Cream */
+    color: #333333; /* Dark grey text */
+    line-height: 1.6; /* Improved readability */
+}
+
+header, footer {
+    text-align: center;
+    margin-bottom: 40px;
+}
+
+main {
+    max-width: 850px; /* Reasonable max-width */
+    margin: 0 auto;
+    background-color: #ffffff; /* White background for content */
+    padding: 25px;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+}
+
+h1, h2, h3 {
+    color: #D2691E; /* Warm accent color - Chocolate (previously #c0392b) */
+    font-family: 'Nunito', 'Arial', sans-serif; /* Playful but readable font */
+}
+
+h1 {
+    font-size: 2.8em; /* Prominent main heading */
+    margin-bottom: 20px; /* Adjusted spacing */
+}
+
+h2 {
+    font-size: 2em; /* Section headings (previously 1.8em) */
+    margin-top: 40px; /* Increased spacing (previously 30px) */
+    border-bottom: 2px solid #eeeeee;
+    padding-bottom: 10px;
+}
+
+h3 {
+    font-size: 1.5em; /* Sub-headings (previously 1.4em) */
+    margin-top: 25px; /* Adjusted spacing (previously 20px) */
+    color: #FF8C00; /* Darker, friendly orange (previously #e67e22) */
+}
+
+pre {
+    background-color: #f0f0f0; /* Very light grey background */
+    padding: 20px; /* Increased padding */
+    border-radius: 5px;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    font-family: 'Courier New', Courier, monospace; /* Monospace font */
+    border: 1px solid #dddddd; /* Border for license blocks */
+    margin-top: 15px; /* Added margin for spacing */
+    margin-bottom: 15px; /* Added margin for spacing */
+}
+
+section {
+    margin-bottom: 35px; /* Increased spacing (previously 30px) */
+}
+
+p, li {
+    line-height: 1.7; /* Slightly increased line-height for readability */
+    font-family: 'Arial', 'Helvetica Neue', sans-serif; /* Friendly sans-serif font for body text */
+}
+
+ul {
+    padding-left: 25px; /* Adjusted padding */
+    list-style-type: disc; /* Standard disc bullets */
+}
+
+footer p {
+    font-size: 0.9em;
+    color: #666666; /* Slightly lighter grey for footer (previously #777) */
+    margin-top: 40px; /* Ensure spacing above footer */
+}
+
+a {
+    color: #D2691E; /* Warm accent color for links */
+    text-decoration: none; /* Remove underline by default */
+}
+
+a:hover {
+    text-decoration: underline; /* Underline on hover for clarity */
+    color: #FF8C00; /* Slightly brighter on hover */
+}
+
+/* Specific styling for "How to Use" section's pre block, if needed */
+/* It already inherits the general 'pre' styling which is appropriate */
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+    body {
+        padding: 15px;
+    }
+    main {
+        padding: 20px;
+    }
+    h1 {
+        font-size: 2.2em;
+    }
+    h2 {
+        font-size: 1.7em;
+    }
+    h3 {
+        font-size: 1.3em;
+    }
+    pre {
+        padding: 15px;
+    }
+}
+
+@media (max-width: 480px) {
+    body {
+        padding: 10px;
+    }
+    main {
+        padding: 15px;
+        margin-left: 10px;
+        margin-right: 10px;
+    }
+    h1 {
+        font-size: 1.8em;
+    }
+    h2 {
+        font-size: 1.5em;
+    }
+    h3 {
+        font-size: 1.2em;
+    }
+    pre {
+        font-size: 0.9em; /* Smaller font for pre on very small screens */
+    }
+}


### PR DESCRIPTION
This commit introduces a simple, joyful, and impactful website for the Cheersware License.

The website consists of:
- `index.html`: The main page displaying the license, its motivation, why to use it, who it's for, and how to use it.
- `style.css`: Stylesheet for a warm, friendly, and readable design, including a responsive layout and the "Nunito" font for headings.
- `README.md`: Updated repository README to explain the purpose of the website and provide instructions on using the Cheersware license.

The license text is prominently displayed, and a copy-pasteable block is provided for easy adoption by you. The design aims to reflect the simple and human-centric nature of the Cheersware license.